### PR TITLE
Stop duplications on unsuccessful file load

### DIFF
--- a/steam-review-extractor.py
+++ b/steam-review-extractor.py
@@ -53,6 +53,7 @@ def extract_reviews(basepath, outputfile_name):
                         soup = BeautifulSoup(json.loads(f.read())['html'], "html.parser")
                     except ValueError:
                         print('error on ', fullpath, file=sys.stderr)
+                        return
                     for reviewdiv in soup.findAll('div', attrs={'class': 'review_box'}):
                         helpful = 0
                         funny = 0


### PR DESCRIPTION
When the review extractor reaches `reviews-done.txt` or any other unnecessary file, it will duplicate last values and write them into .csv file.